### PR TITLE
Added requirements.txt to examples

### DIFF
--- a/fireblocks_defi_sdk_py/examples/requirements.txt
+++ b/fireblocks_defi_sdk_py/examples/requirements.txt
@@ -1,3 +1,3 @@
-fireblocks-defi-sdk
+fireblocks-defi-sdk==1.0.2
 eth-tester==0.8.0b3
 py-evm==0.6.1a2

--- a/fireblocks_defi_sdk_py/examples/requirements.txt
+++ b/fireblocks_defi_sdk_py/examples/requirements.txt
@@ -1,0 +1,3 @@
+fireblocks-defi-sdk
+eth-tester==0.8.0b3
+py-evm==0.6.1a2


### PR DESCRIPTION
eth-tester is needed to use EthereumTesterProvider Without installing py-evm, running the examples raises an error: "TypeError: MockBackend.estimate_gas() takes 2 positional arguments but 3 were given"

After installing the problem is resolved